### PR TITLE
fix: update PR label terminology (ready for code, code review)

### DIFF
--- a/.forge/agents/coder.md
+++ b/.forge/agents/coder.md
@@ -41,16 +41,16 @@ Error: GitHub issue number not provided. Please pass the issue number (e.g., "Im
 2. Get task: `gh issue view <N> --json title,body,labels`
 3. Find PR for the task: `gh pr list --state all --search "<N>" --json number,title,state,labels`
    - If no PR — **STOP**: task has not passed the planning stage
-   - If PR exists but does NOT have label `ready for work` or `in progress` — **STOP** and return:
+   - If PR exists but does NOT have label `ready for code` or `in progress` — **STOP** and return:
      ```
-     Error: PR #<N> does not have label "ready for work" or "in progress". The task is not ready for implementation.
+     Error: PR #<N> does not have label "ready for code" or "in progress". The task is not ready for implementation.
      Current labels: [label list]
      ```
 4. Read review threads in PR:
    - Closed — already resolved questions, accepted decisions
    - Open — review comments to address during implementation
 5. Find all plan files in the PR branch (`plan-*.md`) and read them
-6. Set label `in progress` on PR, remove `ready for work` if present
+6. Set label `in progress` on PR, remove `ready for code` if present
 7. If PR is not draft — convert to draft (`gh pr ready <PR> --undo`) to prevent CI runs during active development
 8. Read specifications referenced in the plans:
    - `requirements.md`
@@ -84,7 +84,7 @@ If any condition is not met — **do NOT finish**, keep fixing. Use `followup` i
 When all conditions are met:
 
 1. Commit remaining changes (if any) and push branch
-2. Set label `review` on PR, removing others
+2. Set label `code review` on PR, removing others
 3. Close all open review threads that were fixed
 4. Return report:
 
@@ -102,7 +102,7 @@ Closed comments:
 - ✅ [comment — link to thread]
 ```
 
-**PR label flow:** `ready for work` -> `in progress` -> `review`
+**PR label flow:** `ready for code` -> `in progress` -> `code review`
 
 ---
 

--- a/.forge/agents/reviewer.md
+++ b/.forge/agents/reviewer.md
@@ -37,9 +37,9 @@ Error: GitHub issue number not provided. Please pass the issue number (e.g., "Re
 2. Get the issue: `gh issue view <N> --json title,body,labels`
 3. Find the PR: `gh pr list --state all --search "<N>" --json number,title,state,labels,headRefOid`
    - If no PR exists — **STOP**: nothing to review
-   - If PR exists but does NOT have the `review` label — **STOP** and return:
+   - If PR exists but does NOT have the `code review` label — **STOP** and return:
      ```
-     Error: PR #<N> does not have label "review". The task is not ready for review.
+     Error: PR #<N> does not have label "code review". The task is not ready for review.
      Current labels: [list of labels]
      ```
 4. If PR is draft — mark as ready (`gh pr ready <PR>`) so CI checks can run
@@ -110,8 +110,8 @@ Check each item and leave inline threads in the PR for every finding.
    - **Not ready to merge** — at least one finding of any priority OR any CI check failed
 4. Submit review in PR via `gh api repos/<owner>/<repo>/pulls/<PR>/reviews` with event `COMMENT` and the full report
 5. Set the final label on PR:
-   - **`ready for test`** — ready to merge. Remove `review`
-   - **`in progress`** — not ready to merge. Remove `review`
+   - **`ready for test`** — ready to merge. Remove `code review`
+   - **`in progress`** — not ready to merge. Remove `code review`
 6. Return report:
 
 ```
@@ -149,5 +149,5 @@ Created threads:
 - 🚫 — issues found: list + links to created inline threads
 - 🥺 — not applicable (with reason)
 
-**PR label flow:** `review` -> `ready for test` (approved) or `in progress` (needs rework by coder)
+**PR label flow:** `code review` -> `ready for test` (approved) or `in progress` (needs rework by coder)
 

--- a/.forge/agents/solver.md
+++ b/.forge/agents/solver.md
@@ -42,7 +42,7 @@ Which task should I work on? Please provide a GitHub issue number (e.g., #89).
                                             | Human approves plan
                                             v
                                      +----------------+
-                                     | ready for work |
+                                     | ready for code |
                                      +----------------+
                                             |
                                             | Coder (first run)
@@ -77,9 +77,9 @@ Determine the current PR label (or absence of PR) and proceed to the correspondi
 | PR with label `new`           | -> Run **planner** (Step 2)         |
 | PR with label `analysis`      | -> Run **planner** (Step 2)         |
 | PR with label `analysis review` | -> Human approval (Step 3)       |
-| PR with label `ready for work`  | -> Run **coder** (Step 4)        |
+| PR with label `ready for code`  | -> Run **coder** (Step 4)        |
 | PR with label `in progress`     | -> Run **coder** (Step 4)        |
-| PR with label `review`          | -> Run **reviewer** (Step 5)     |
+| PR with label `code review`          | -> Run **reviewer** (Step 5)     |
 | PR with label `ready for test`  | -> Task already complete (Step 6)|
 
 ### Step 2: Planning (planner)
@@ -108,30 +108,30 @@ Determine the current PR label (or absence of PR) and proceed to the correspondi
    Plan file: <path>
 
    Please review the plan and:
-   - If approved — set label `ready for work` on the PR
+   - If approved — set label `ready for code` on the PR
    - If changes needed — leave inline comments on the PR
 
    Reply when ready to proceed.
    ```
 2. **STOP and wait for the user's response**
 3. When the user replies — check the PR label:
-   - `ready for work` — proceed to **Step 4**
+   - `ready for code` — proceed to **Step 4**
    - `analysis review` (label unchanged) — check open inline threads in the PR:
      - If there are open threads — user left comments. Proceed to **Step 2** (re-run planner)
-     - If no open threads — user approved the plan but did not change the label. Remove `analysis review`, set `ready for work`, and proceed to **Step 4**
+     - If no open threads — user approved the plan but did not change the label. Remove `analysis review`, set `ready for code`, and proceed to **Step 4**
 
 ### Step 4: Implementation (coder)
 
-**When:** PR has label `ready for work` or `in progress`.
+**When:** PR has label `ready for code` or `in progress`.
 
 1. Run **coder** agent with the issue number
 2. After completion, check the PR label:
-   - `review` — implementation complete. Proceed to **Step 5**
+   - `code review` — implementation complete. Proceed to **Step 5**
    - Coder returned a question via `followup` — relay the question to the user, wait for the answer, re-run **coder** (repeat Step 4)
 
 ### Step 5: Review (reviewer)
 
-**When:** PR has label `review`.
+**When:** PR has label `code review`.
 
 1. Run **reviewer** agent with the issue number
 2. After completion, check the PR label:


### PR DESCRIPTION
Re-applies the label terminology update that was originally committed directly to main (d5ff7d3, reverted in #101).

### Changes

Updates PR label names in all agent definitions for consistency:
- `ready for work` -> `ready for code`
- `review` -> `code review`

Files changed:
- `.forge/agents/solver.md`
- `.forge/agents/coder.md`
- `.forge/agents/reviewer.md`