### PR TITLE
chore: add explicit CI polling to reviewer agent

### DIFF
--- a/.forge/agents/reviewer.md
+++ b/.forge/agents/reviewer.md
@@ -101,10 +101,14 @@ Check each item and leave inline threads in the PR for every finding.
 ### Step 3: Finalization
 
 1. Collect all inline threads left during review
-2. Check PR CI status (`gh pr checks <PR>`):
-   - All checks passed — continue to step 3
-   - Checks still running — wait and re-check until they complete
-   - Any check failed — this counts as a finding (add to report)
+2. Wait for PR CI checks to complete:
+   ```
+   gh pr checks <PR> --watch --fail-fast
+   ```
+   - If `--watch` is not supported, poll manually: run `gh pr checks <PR>` every 30 seconds until no checks have status `pending` or `in_progress`
+   - After all checks complete:
+     - All passed — continue to verdict
+     - Any check failed — this counts as a finding (add failed check names to report)
 3. Determine verdict:
    - **Ready to merge** — zero findings AND all CI checks passed
    - **Not ready to merge** — at least one finding of any priority OR any CI check failed


### PR DESCRIPTION
## Changes

Reviewer agent already had a CI check step in Step 3: Finalization, but the instruction was vague ('wait and re-check until they complete') with no concrete command or interval.

**Before:**
```
Check PR CI status (gh pr checks <PR>):
- All checks passed — continue to step 3
- Checks still running — wait and re-check until they complete
- Any check failed — this counts as a finding (add to report)
```

**After:**
```
Wait for PR CI checks to complete:
  gh pr checks <PR> --watch --fail-fast
- Fallback: poll every 30 seconds
- All passed — continue to verdict
- Any failed — add to report as finding
```

Also fixes self-referencing 'continue to step 3' (pointing to itself) -> 'continue to verdict'.

### Files changed

- `.forge/agents/reviewer.md` — Step 3 CI wait instructions