### PR TITLE
chore: enforce gate-label prohibition in solver workflow

### DIFF
--- a/.forge/agents/solver.md
+++ b/.forge/agents/solver.md
@@ -12,6 +12,7 @@ custom_rules: |
   - You are an orchestrator. NEVER write code, specifications, or reviews yourself — delegate to agents.
   - Always check PR labels before and after each agent run.
   - NEVER skip the human approval step between planner and coder — use polling to wait for label changes.
+  - GATE LABELS — `analysis review` and `ready for test` require EXPLICIT human action (label change) to advance. When the current PR label is a gate label, you MUST NOT proceed to the next stage under any circumstances. The ONLY valid actions are: (1) answer review comments, (2) re-run planner if new review threads appear, (3) poll and wait. Advancing past a gate label without the human changing it is FORBIDDEN — even if all review comments are answered, even if the plan looks complete, even if there are no open threads.
 reasoning:
   enabled: true
   effort: low
@@ -77,12 +78,14 @@ Determine the current PR label (or absence of PR) and proceed to the correspondi
 |-------------------------------|-------------------------------------|
 | PR does not exist             | -> Run **planner** (Step 2)         |
 | PR with label `analysis`      | -> Run **planner** (Step 2)         |
-| PR with label `analysis review` | -> Human approval (Step 3)       |
+| PR with label `analysis review` | -> Human approval (Step 3) **GATE** |
 | PR with label `ready for code`  | -> Run **coder** (Step 4)        |
 | PR with label `in progress`     | -> Run **coder** (Step 4)        |
 | PR with label `code review`          | -> Run **reviewer** (Step 5)     |
-| PR with label `ready for test`  | -> Task already complete (Step 6)|
+| PR with label `ready for test`  | -> Task already complete (Step 6) **GATE** |
 | PR is MERGED or CLOSED         | -> Stop (Step 7)                   |
+
+**Gate labels** (`analysis review`, `ready for test`) require explicit human label change to advance. Never infer or assume approval — only the label matters.
 
 ### Step 2: Planning (planner)
 
@@ -107,9 +110,11 @@ Determine the current PR label (or absence of PR) and proceed to the correspondi
      When polling detects a change — re-run **planner** (repeat Step 2).
      If 60 minutes elapse with no change — stop with timeout report (see Timeout section).
 
-### Step 3: Human approval
+### Step 3: Human approval (GATE — label change required)
 
 **When:** PR has label `analysis review`.
+
+**CRITICAL:** `analysis review` is a **gate label**. The ONLY way to proceed to Step 4 is when the human changes the label to `ready for code`. You MUST NOT advance past this step by any other means — not by answering comments, not by inferring approval, not by any heuristic. If the label is still `analysis review`, you stay in this step.
 
 1. Print status message:
    ```


### PR DESCRIPTION
## Summary

Enforce strict gate-label prohibition in the solver agent workflow to prevent advancing past human-approval stages without explicit label change.

### Problem

The solver agent attempted to proceed from `analysis review` to implementation (Phase 2) after answering a review comment, without waiting for the human to change the label to `ready for code`.

### Changes

- **custom_rules**: Added GATE LABELS rule — `analysis review` and `ready for test` require explicit human label change to advance. Advancing without it is forbidden under any circumstances.
- **Step 1 dispatch table**: Marked `analysis review` and `ready for test` as **GATE** with explanatory note.
- **Step 3**: Renamed to "Human approval (GATE — label change required)", added CRITICAL block explicitly prohibiting advancement without label change.